### PR TITLE
Remove exact eigen requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,12 +7,13 @@ package:
 source:
   url: http://ceres-solver.org/ceres-solver-{{ version }}.tar.gz
   sha256: 10298a1d75ca884aa0507d1abb0e0f04800a92871cd400d4c361b56a777a7603
+  patches:
+    - remove-exact-eigen-requirement.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('ceres-solver', max_pin='x.x') }}
-    - {{ pin_compatible('eigen', max_pin='x.x.x') }}
 
 requirements:
   build:

--- a/recipe/remove-exact-eigen-requirement.patch
+++ b/recipe/remove-exact-eigen-requirement.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/CeresConfig.cmake.in b/cmake/CeresConfig.cmake.in
+index e5e2976..184d4eb 100644
+--- a/cmake/CeresConfig.cmake.in
++++ b/cmake/CeresConfig.cmake.in
+@@ -193,17 +193,6 @@ set(CERES_EIGEN_VERSION @EIGEN3_VERSION_STRING@)
+ # match and reject with an explanation below.
+ find_package(Eigen3 ${CERES_EIGEN_VERSION} QUIET)
+ if (EIGEN3_FOUND)
+-  if (NOT EIGEN3_VERSION_STRING VERSION_EQUAL CERES_EIGEN_VERSION)
+-    # CMake's VERSION check in FIND_PACKAGE() will accept any version >= the
+-    # specified version. However, only version = is supported. Improve
+-    # usability by explaining why we don't accept non-exact version matching.
+-    ceres_report_not_found("Found Eigen dependency, but the version of Eigen "
+-      "found (${EIGEN3_VERSION_STRING}) does not exactly match the version of Eigen "
+-      "Ceres was compiled with (${CERES_EIGEN_VERSION}). This can cause subtle "
+-      "bugs by triggering violations of the One Definition Rule. See the "
+-      "Wikipedia article http://en.wikipedia.org/wiki/One_Definition_Rule "
+-      "for more details")
+-  endif ()
+   ceres_message(STATUS "Found required Ceres dependency: "
+     "Eigen version ${CERES_EIGEN_VERSION} in ${EIGEN3_INCLUDE_DIRS}")
+ else (EIGEN3_FOUND)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
See https://github.com/conda-forge/ceres-solver-feedstock/issues/19 for reasoning. Basically ceres requires that Eigen is unnecessarily the exact same version when compiling downstream pacakges. Fix https://github.com/conda-forge/ceres-solver-feedstock/issues/19