### PR TITLE
Provide variants for gpl and lgpl dependencies

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,24 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cuda_compiler_version12.9:
-        CONFIG: linux_64_cuda_compiler_version12.9
+      linux_64_cuda_compiler_version12.9dep_license_familygpl:
+        CONFIG: linux_64_cuda_compiler_version12.9dep_license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cuda_compiler_versionNone:
-        CONFIG: linux_64_cuda_compiler_versionNone
+      linux_64_cuda_compiler_version12.9dep_license_familylgpl:
+        CONFIG: linux_64_cuda_compiler_version12.9dep_license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compiler_version12.9:
-        CONFIG: linux_aarch64_cuda_compiler_version12.9
+      linux_64_cuda_compiler_versionNonedep_license_familygpl:
+        CONFIG: linux_64_cuda_compiler_versionNonedep_license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compiler_versionNone:
-        CONFIG: linux_aarch64_cuda_compiler_versionNone
+      linux_64_cuda_compiler_versionNonedep_license_familylgpl:
+        CONFIG: linux_64_cuda_compiler_versionNonedep_license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_:
-        CONFIG: linux_ppc64le_
+      linux_aarch64_cuda_compiler_version12.9dep_license_familygpl:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9dep_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl:
+        CONFIG: linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_versionNonedep_license_familygpl:
+        CONFIG: linux_aarch64_cuda_compiler_versionNonedep_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl:
+        CONFIG: linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_dep_license_familygpl:
+        CONFIG: linux_ppc64le_dep_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_dep_license_familylgpl:
+        CONFIG: linux_ppc64le_dep_license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: macOS-15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_dep_license_familygpl:
+        CONFIG: osx_64_dep_license_familygpl
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_dep_license_familylgpl:
+        CONFIG: osx_64_dep_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_dep_license_familygpl:
+        CONFIG: osx_arm64_dep_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_dep_license_familylgpl:
+        CONFIG: osx_arm64_dep_license_familylgpl
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_cuda_compiler_version12.9:
-        CONFIG: win_64_cuda_compiler_version12.9
+      win_64_cuda_compiler_version12.9dep_license_familygpl:
+        CONFIG: win_64_cuda_compiler_version12.9dep_license_familygpl
         UPLOAD_PACKAGES: 'True'
-      win_64_cuda_compiler_versionNone:
-        CONFIG: win_64_cuda_compiler_versionNone
+      win_64_cuda_compiler_version12.9dep_license_familylgpl:
+        CONFIG: win_64_cuda_compiler_version12.9dep_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_versionNonedep_license_familygpl:
+        CONFIG: win_64_cuda_compiler_versionNonedep_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_versionNonedep_license_familylgpl:
+        CONFIG: win_64_cuda_compiler_versionNonedep_license_familylgpl
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_cuda_compiler_version12.9dep_license_familygpl.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.9dep_license_familygpl.yaml
@@ -1,0 +1,41 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+dep_license_family:
+- gpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_version12.9dep_license_familylgpl.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.9dep_license_familylgpl.yaml
@@ -1,0 +1,41 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+dep_license_family:
+- lgpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_versionNonedep_license_familygpl.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonedep_license_familygpl.yaml
@@ -1,37 +1,41 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_compiler:
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+dep_license_family:
+- gpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 glog:
 - '0.7'
 libblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_versionNonedep_license_familylgpl.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonedep_license_familylgpl.yaml
@@ -13,11 +13,13 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '14'
+dep_license_family:
+- lgpl
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 glog:
@@ -28,8 +30,10 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9dep_license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9dep_license_familygpl.yaml
@@ -1,0 +1,41 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+dep_license_family:
+- gpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl.yaml
@@ -1,0 +1,41 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+dep_license_family:
+- lgpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonedep_license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonedep_license_familygpl.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '14'
+dep_license_family:
+- gpl
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 glog:
@@ -28,6 +30,8 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl.yaml
@@ -10,12 +10,16 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_compiler:
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '14'
+dep_license_family:
+- lgpl
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 glog:
@@ -26,8 +30,10 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_dep_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_dep_license_familygpl.yaml
@@ -10,14 +10,14 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '14'
+dep_license_family:
+- gpl
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 glog:
@@ -28,8 +28,10 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_dep_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_dep_license_familylgpl.yaml
@@ -1,0 +1,39 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+dep_license_family:
+- lgpl
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/osx_64_dep_license_familygpl.yaml
+++ b/.ci_support/osx_64_dep_license_familygpl.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+dep_license_family:
+- gpl
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_dep_license_familylgpl.yaml
+++ b/.ci_support/osx_64_dep_license_familylgpl.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -20,6 +20,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+dep_license_family:
+- lgpl
 glog:
 - '0.7'
 libblas:
@@ -27,11 +29,13 @@ libblas:
 liblapack:
 - 3.9.* *netlib
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_dep_license_familygpl.yaml
+++ b/.ci_support/osx_arm64_dep_license_familygpl.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+dep_license_family:
+- gpl
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_dep_license_familylgpl.yaml
+++ b/.ci_support/osx_arm64_dep_license_familylgpl.yaml
@@ -1,37 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
+dep_license_family:
+- lgpl
 glog:
 - '0.7'
 libblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+macos_machine:
+- arm64-apple-darwin20.0.0
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/win_64_cuda_compiler_version12.9dep_license_familygpl.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9dep_license_familygpl.yaml
@@ -12,6 +12,8 @@ cuda_compiler_version:
 - '12.9'
 cxx_compiler:
 - vs2022
+dep_license_family:
+- gpl
 glog:
 - '0.7'
 libblas:
@@ -20,5 +22,7 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
 - win-64

--- a/.ci_support/win_64_cuda_compiler_version12.9dep_license_familylgpl.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9dep_license_familylgpl.yaml
@@ -1,0 +1,28 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- vs2022
+dep_license_family:
+- lgpl
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_versionNonedep_license_familygpl.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonedep_license_familygpl.yaml
@@ -12,6 +12,8 @@ cuda_compiler_version:
 - None
 cxx_compiler:
 - vs2022
+dep_license_family:
+- gpl
 glog:
 - '0.7'
 libblas:
@@ -20,5 +22,7 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+suitesparse:
+- '7'
 target_platform:
 - win-64

--- a/.ci_support/win_64_cuda_compiler_versionNonedep_license_familylgpl.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonedep_license_familylgpl.yaml
@@ -1,0 +1,28 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- vs2022
+dep_license_family:
+- lgpl
+glog:
+- '0.7'
+libblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+suitesparse:
+- '7'
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -27,66 +27,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cuda_compiler_version12.9</td>
+              <td>linux_64_cuda_compiler_version12.9dep_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.9dep_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compiler_versionNone</td>
+              <td>linux_64_cuda_compiler_version12.9dep_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_versionNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.9dep_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compiler_version12.9</td>
+              <td>linux_64_cuda_compiler_versionNonedep_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_versionNonedep_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compiler_versionNone</td>
+              <td>linux_64_cuda_compiler_versionNonedep_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_versionNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_versionNonedep_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_aarch64_cuda_compiler_version12.9dep_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9dep_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9dep_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_aarch64_cuda_compiler_versionNonedep_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_versionNonedep_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compiler_version12.9</td>
+              <td>linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_versionNonedep_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compiler_versionNone</td>
+              <td>linux_ppc64le_dep_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_dep_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_dep_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_dep_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_dep_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_dep_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_dep_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_dep_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_dep_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_dep_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_dep_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_dep_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version12.9dep_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9dep_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version12.9dep_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9dep_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_versionNonedep_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonedep_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_versionNonedep_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ceres-solver-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonedep_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,13 +8,18 @@ if NOT "%cuda_compiler_version%"=="None" (
     set CUDA_ENABLED=OFF
 )
 
+if "%dep_license_family%"=="gpl" (
+    set "EXTRA_CMAKE_ARGS=%EXTRA_CMAKE_ARGS% -DSUITESPARSE=ON"
+) else (
+    set "EXTRA_CMAKE_ARGS=%EXTRA_CMAKE_ARGS% -DSUITESPARSE=OfF"
+)
+
 cmake -G "NMake Makefiles" ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DUSE_CUDA=%CUDA_ENABLED% ^
     -DBLA_VENDOR=Generic ^
-    -DSUITESPARSE=OFF ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_EXAMPLES=OFF ^
     -DBUILD_TESTING=OFF ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,12 +13,19 @@ if [[ ! -z "${cuda_compiler_version+x}" && "${cuda_compiler_version}" != "None" 
     EXTRA_CMAKE_ARGS="-DUSE_CUDA=OFF"
 fi
 
+if [[ "${dep_license_family}" == "gpl" ]]; 
+  then
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DSUITESPARSE=ON"
+  else
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DSUITESPARSE=OFF"
+fi
+
 cmake ${CMAKE_ARGS} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DBLA_VENDOR="Generic" \
   -DACCELERATESPARSE=OFF \
-  -DSUITESPARSE=OFF \
+   \
   -DBUILD_SHARED_LIBS=ON \
   -DBUILD_EXAMPLES=OFF \
   -DBUILD_TESTING=OFF \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+dep_license_family:
+  - lgpl
+  - gpl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,17 @@
 {% set processor = "cpu" if (cuda_compiler_version or "None") == "None" else "gpu" %}
 
 # Prioritize gpu build if cudatoolkit can be installed (through __cuda virtual package)
-{% set build = 8 %}
+{% set build = 9 %}
 {% set build = build + 100 if processor == "gpu" else build %}
+
+# ceres by itself is BSD-3-Clause, but it can depend on SuiteSparse (gpl) or an lgpl part of
+# Eigen. For these reason, similarly to the ffmpeg-feedstock, we provide gpl and lgpl
+# variants of the suitesparse package, where in this case gpl and lgpl does refer to the
+# license of some of the dependencies, not the package itself.
+# See https://github.com/ceres-solver/ceres-solver/issues/1026
+# https://github.com/ceres-solver/ceres-solver/commit/aab0193c7b8e7a747855ec6b03332dba19c078c2#diff-e285c1b9901cd202e89d9f37e3249a6fee524a65428895e1a45fd062cc0f9acaR594-R610 
+{% set dep_license_family = dep_license_family | default("gpl") %}
+{% set build = build + 200 if dep_license_family == "gpl" else build %}
 
 package:
   name: ceres-solver
@@ -15,7 +24,7 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ processor }}h{{ PKG_HASH }}_{{ build }}
+  string: {{ processor }}{{ dep_license_family }}h{{ PKG_HASH }}_{{ build }}
   skip: true  # [cuda_compiler_version == "11.8"]
   run_exports:
     - {{ pin_subpackage('ceres-solver', max_pin='x.x') }}
@@ -38,7 +47,7 @@ requirements:
     - libblas
     - liblapack
     - metis
-    #- suitesparse (disable because GPL: https://github.com/ceres-solver/ceres-solver/issues/1026)
+    - suitesparse                               # [dep_license_family == "gpl"]
     - eigen
     - libcublas-dev                             # [(cuda_compiler_version or "None").startswith("12")]
     - libcusolver-dev                           # [(cuda_compiler_version or "None").startswith("12")]


### PR DESCRIPTION
Fix https://github.com/conda-forge/ceres-solver-feedstock/issues/51 .

For backward compatibility the `gpl` variant has higher priority, but users that do not want to use the `gpl` dependency can add a build string dependency on `*lgpl*`, as done in the ffmpeg-feedstock.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
